### PR TITLE
Fix the revenue table

### DIFF
--- a/Financials.md
+++ b/Financials.md
@@ -48,54 +48,52 @@ Options Pool | 7.38%
 33cube, Inc. Profit & Loss
 --------------------------
 
-October 19th, 2011 - December 15th, 2013 | Accrual Basis
------|-----:
- | 
-Income | 
-&nbsp;&nbsp;&nbsp;&nbsp;Everpix Subscriptions | 269,974.47
-&nbsp;&nbsp;&nbsp;&nbsp;Refunded Purchases | 2,696.78
-&nbsp;&nbsp;&nbsp;&nbsp;Vendor Credits | 7,451.31
-&nbsp;&nbsp;&nbsp;&nbsp;Interest Earned | 573.82
-**Total Income** | **$280,696.38**
- | 
-Expenses | 
-&nbsp;&nbsp;&nbsp;&nbsp;Bank Charges | 1,396.70
-&nbsp;&nbsp;&nbsp;&nbsp;Government Fees | 8,827.20
-&nbsp;&nbsp;&nbsp;&nbsp;Legal & Professional Fees | 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Accountants | 9,251.95
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Consultants | 272,821.83
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Legal | 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;General Corporate | 85,775.46
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;General Patent | 37,463.52
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Immigration | 2,215.00
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Initial Bridge Financing | 27,086.56
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Investors Legal Costs | 20,722.05
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Series Seed Preferred Stock Financing | 15,351.23
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Public Relations | 109,552.34
-&nbsp;&nbsp;&nbsp;&nbsp;Office Expenses | 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Entertainment Meals | 2,022.27
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Food & Beverages | 8,073.03
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Hardware | 10,981.09
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Insurance | 2,446.00
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Miscellaneous | 4,829.51
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Rent | 95,085.24
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Service Subscriptions | 5,039.84
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Software | 2,172.05
-&nbsp;&nbsp;&nbsp;&nbsp;Operating Costs | 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Amazon Mechanical Turk | 8,916.75
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Amazon Web Services | 394,588.35
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Google App Engine | 7,878.01
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Other Cloud Infrastructure | 15,699.84
-&nbsp;&nbsp;&nbsp;&nbsp;Personnel Costs | 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Health Care | 62,653.68
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Miscellaneous | 1,442.18
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Payroll | 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Salaries | 832,347.83
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Withholding | 360,025.20
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Taxes | 130,486.03
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Recruiting | 51,836.00
-&nbsp;&nbsp;&nbsp;&nbsp;Promotional Expenses | 48,007.80
-&nbsp;&nbsp;&nbsp;&nbsp;Travel Expenses | 30,197.80
-**Total Expenses** | **$2,665,192.34**
- | 
-**Net Operating Income** | **-$2,384,224.67**
+| October 19th, 2011 - December 15th, 2013 |     Accrual Basis |
+|------------------------------------------|------------------:|
+|                                          |                   |
+| Income                                   |                   |
+| Everpix Subscriptions                    |        269,974.47 |
+| Refunded Purchases                       |          2,696.78 |
+| Vendor Credits                           |          7,451.31 |
+| Interest Earned                          |            573.82 |
+| **Total Income**                         |   **$280,696.38** |
+| Expenses                                 |                   |
+| Bank Charges                             |          1,396.70 |
+| Government Fees                          |          8,827.20 |
+| Legal & Professional Fees                |                   |
+| Accountants                              |          9,251.95 |
+| Consultants                              |        272,821.83 |
+| Legal                                    |                   |
+| General Corporate                        |         85,775.46 |
+| General Patent                           |         37,463.52 |
+| Immigration                              |          2,215.00 |
+| Initial Bridge Financing                 |         27,086.56 |
+| Investors Legal Costs                    |         20,722.05 |
+| Series Seed Preferred Stock Financing    |         15,351.23 |
+| Public Relations                         |        109,552.34 |
+| Office Expenses                          |                   |
+| Entertainment Meals                      |          2,022.27 |
+| Food & Beverages                         |          8,073.03 |
+| Hardware                                 |         10,981.09 |
+| Insurance                                |          2,446.00 |
+| Miscellaneous                            |          4,829.51 |
+| Rent                                     |         95,085.24 |
+| Service Subscriptions                    |          5,039.84 |
+| Software                                 |          2,172.05 |
+| Operating Costs                          |                   |
+| Amazon Mechanical Turk                   |          8,916.75 |
+| Amazon Web Services                      |        394,588.35 |
+| Google App Engine                        |          7,878.01 |
+| Other Cloud Infrastructure               |         15,699.84 |
+| Personnel Costs                          |                   |
+| Health Care                              |         62,653.68 |
+| Miscellaneous                            |          1,442.18 |
+| Payroll                                  |                   |
+| Salaries                                 |        832,347.83 |
+| Withholding                              |        360,025.20 |
+| Taxes                                    |        130,486.03 |
+| Recruiting                               |         51,836.00 |
+| Promotional Expenses                     |         48,007.80 |
+| Travel Expenses                          |         30,197.80 |
+| **Total Expenses**                       | **$2,665,192.34** |
+| **Net Operating Income**                 | **$2,384,224.67** |


### PR DESCRIPTION
Fixed the revenue table. The problem starts at this line: 

https://github.com/everpix/Everpix-Intelligence/blob/e00017f0e63287d2f93035104c9f515f51349c55/Financials.md?plain=1#L44

I've done a before/after so you can see the difference, as you can see this table is broken. This is where I began the new table:

https://github.com/everpix/Everpix-Intelligence/blob/e00017f0e63287d2f93035104c9f515f51349c55/Financials.md?plain=1#L45

**_Before:_** 

<img width="1127" alt="Screenshot 2022-11-18 at 7 01 16 PM" src="https://user-images.githubusercontent.com/20936398/202831183-6e8f70b8-3a3e-4f65-9576-0db096a5e1fb.png">

This is the fixed table, I've made a PR that would fix currently the `Financials.md` file, and make it possible to read in Markdown form. 

https://github.com/Montana/Everpix-Intelligence/blob/patch-1/Financials.md

**_After:_**

<img width="471" alt="Screenshot 2022-11-18 at 7 02 05 PM" src="https://user-images.githubusercontent.com/20936398/202831190-a67ff149-d05c-4a0f-aaa6-7e61f6c717d6.png">

Thank you,
Montana Mendy